### PR TITLE
add module1 solution

### DIFF
--- a/module1/workshop/style.css
+++ b/module1/workshop/style.css
@@ -12,164 +12,68 @@ body {
 
 /* Add styles here! */
 
-/* Ended up learning:
-- use margins for positioning the elements
-- use padding for set where the text starts and ends
-- media queries for different screen sizes
-- width: fit-content turned out to be useful
-*/
+header {
+  border-bottom: 8px solid hsl(0deg, 0%, 60%);
+}
 
-/* Probable improvements
-- use percentages for positioning instead of relying on pixels ?
-- somehow not rely on explicit height dimensions
-- style `max-width-wrapper`
- */
-
-.title {
-  margin-top: 0px;
-  margin-bottom: 32px;
+h1 {
   font-size: 2rem;
+  line-height: 1.2;
+  margin: 0;
+  margin-bottom: 3rem;
+}
+
+p {
+  font-size: 1.25rem;
+  line-height: 1.5;
+  margin: 0px;
+  margin-bottom: 1rem;
+}
+/* override final paragraphs to remove their bottom margins */
+p:last-child {
+  margin-bottom: 0px;
 }
 
 strong {
   color: hsl(160deg, 100%, 30%)
 }
 
-header {
-  background-color: hsl(0deg, 0%, 100%);
-  margin: 96px 0px 0px 0px;
-  border-bottom: solid 8px hsl(0deg, 0%, 60%);
+.max-width-wrapper {
+  max-width: 800px;
+  /* auto: take the free space around an element and distribute it evenly on
+    both sides, so centering that element
+  */
+  margin: 0 auto;
+  padding: 0px 24px;
+}
+
+.intro-chunk {
+  max-width: 415px;
+  padding-top: 96px;
+  padding-bottom: 64px;
 }
 
 main {
-  border: solid 1px hsl(0deg, 0%, 40%);
   background-color: hsl(0deg, 0%, 40%);
+  padding: 64px 0;
 }
 
-/* Desktop */
-@media (min-width: 768px) {
-  header {
-    width: 1280px;
-    height: 294px;
-  }
-  
-  .intro-chunk {
-    min-height: 100%;
-    padding: 0px 601px 64px 264px;
-  }
-  
-  p {
-    margin-top: 16px;
-    margin-bottom: 16px;
-    font-size: 1.25rem;
-  }
-  
-  main {
-    width: 1280px;
-    height: 450px;
-  }
-  
-  .card {
-    border: solid 1px hsl(0deg, 0%, 40%);
-    border-bottom: solid 8px hsl(0deg, 0%, 60%);
-    margin: 72px 240px 58px 232px;
-    padding: 0px 24px 24px 24px;
-    background-color: hsl(0deg, 0%, 100%);
-  }
-  
-  .indented-heading {
-    font-size: 1.5rem;
-    text-align: center;
-    background: hsl(45deg, 100%, 50%);
-    width: fit-content;
-    padding: 16px 32px;
-    margin-left: -32px;
-    border-bottom: solid 8px hsl(45deg, 100%, 40%);
-  }
+.card {
+  background-color: white;
+  padding: 24px;
+  margin: 0px -24px;
+  border-bottom: solid 8px hsl(0deg, 0%, 60%);
 }
 
-/* Tablet */
-@media (min-width: 391px) and (max-width: 768px) {
-  header {
-    width: 768px;
-    height: 390px;
-  }
-
-  .intro-chunk {
-    min-height: 100%;
-    padding: 0px 343px 64px 24px;
-  }
-
-  p {
-    margin-top: 16px;
-    margin-bottom: 16px;
-    font-size: 1.25rem;
-  }
-
-  main {
-    width: 768px;
-    height: 456px;
-  }
-
-  .card {
-    border: solid 1px hsl(0deg, 0%, 40%);
-    border-bottom: solid 8px hsl(0deg, 0%, 60%);
-    margin: 72px 0px 64px 0px;
-    padding: 0px 24px 24px 24px;
-    background-color: hsl(0deg, 0%, 100%);
-  }
-
-  .indented-heading {
-    font-size: 1.5rem;
-    text-align: center;
-    background: hsl(45deg, 100%, 50%);
-    width: fit-content;
-    padding: 16px 32px 16px 24px;
-    margin-top: 8px;
-    margin-left: -24px;
-    border-bottom: solid 8px hsl(45deg, 100%, 40%);
-  }
-}
-
-/* Mobile */
-@media (max-width: 390px) {
-
-  header {
-    width: 390px;
-    height: 390px;
-  }
-
-  .intro-chunk {
-    min-height: 100%;
-    padding: 0px 24px 64px 24px;
-  }
-
-  p {
-    margin-top: 16px;
-    margin-bottom: 16px;
-    font-size: 1.25rem;
-    width: fit-content;
-  }
-
-  main {
-    width: 390px;
-    height: 767px;
-  }
-
-  .card {
-    border: solid 1px hsl(0deg, 0%, 40%);
-    border-bottom: solid 8px hsl(0deg, 0%, 60%);
-    margin: 72px 0px 64px 0px;
-    padding: 0px 24px 24px 24px;
-    background-color: hsl(0deg, 0%, 100%);
-  }
-
-  .indented-heading {
-    font-size: 1.5rem;
-    text-align: left;
-    background: hsl(45deg, 100%, 50%);
-    padding: 12px 24px 12px 24px;
-    margin: 8px 0px 0px -24px;
-    border-bottom: solid 8px hsl(45deg, 100%, 40%);
-  }
+.indented-heading {
+  width: fit-content;
+  font-size: 1.5rem;
+  line-height: 1.2;
+  margin: 0;
+  margin-left: -32px;
+  margin-top: -16px; /* 24px of padding - x = 8px  */
+  margin-bottom: 1rem;
+  padding: 16px 32px;  
+  background: hsl(45deg, 100%, 50%);
+  border-bottom: solid 8px hsl(45deg, 100%, 40%);
 }


### PR DESCRIPTION
learned:
- constrain text content with the size of the "box" that's in Figma (use dimensions in blue), I had previously constrained them with padding and "red" dimensions in Figma.
- know when to style html elements (like `h1`, `p`)  versus class attributes like `.intro-chunk`